### PR TITLE
Feature/bz/swap anim for realtime rig at publish method 4

### DIFF
--- a/openpype/hosts/maya/plugins/create/create_rig.py
+++ b/openpype/hosts/maya/plugins/create/create_rig.py
@@ -21,6 +21,7 @@ class CreateRig(plugin.MayaCreator):
 
         self.log.info("Creating Rig instance set up ...")
         controls = cmds.sets(name=subset_name + "_controls_SET", empty=True)
-        jointExtract = cmds.sets(name=subset_name + "_joints_SET", empty=True)
+        joints = cmds.sets(name=subset_name + "_joints_SET", empty=True)
         pointcache = cmds.sets(name=subset_name + "_out_SET", empty=True)
-        cmds.sets([controls, pointcache,jointExtract], forceElement=instance_node)
+        realtime_geo = cmds.sets(name=subset_name + "_realtime_out_SET", empty=True)
+        cmds.sets([controls, pointcache,joints,realtime_geo], forceElement=instance_node)

--- a/openpype/hosts/maya/plugins/publish/extract_rig.py
+++ b/openpype/hosts/maya/plugins/publish/extract_rig.py
@@ -164,7 +164,7 @@ class ExtractUnrealSkeletalMeshFbxRig(ExtractRig):
                       force=True,
                       # NOTE temporarily exporing as a binary file as the realtime
                       # representation, as just adding realtime to the name and
-                      # doing an ascii important fails saying there already is
+                      # doing an ascii export fails saying there already is
                       # a transaction for the same representation. TODO
                       typ="mayaBinary",  # noqa: E501
                       exportSelected=True,


### PR DESCRIPTION
## Changelog Description
### Animation/Realtime split
Add support for having 2 different representations of Maya rigs - _animation_ and _realtime_ - so the _animation_ rig can be optimised, by removing any non-realtime parts of it. Then at animation publish time, swap out the _animation_ reference for the _realtime_ reference, so we can cache out the realtime skeleton.

Additionally, add a temporary solution for assigning the realtime shaders to the fbx export, so we get the material slots in UE. Temporary, as the code currently directly copies the functionality from `assign_look`, but with small tweaks, which I am hoping to merge into `assign_look` itself.

## Testing notes:
1. Create a rig instance and ensure the following set memberships:
- `_controls_SET` - the animation rig
- `_joints_SET` - the realtime skeleton driven by the animation rig
- `_realtime_out_SET` - all geometries we want to be part of the fbx
- `_out_SET` - doesn't matter, as we only export animation as fbx, so this set which is used for geometry caching is not being used

2. Publish the rig, which will publish the following 3 representations:
- `.ma` file with the `_controls_SET` only, used for animation
- `.mb` file with the `_controls_SET` and `_joints_SET`, which is used for animation publishing
- `.fbx` file with the `_realtime_out_SET` and the `_joints_SET`, which is used as the _skeletal_ mesh and _skeleton_ in UE

3. Bring in the `.ma` animation rig in any animation scene and animate it.

4. Publish the animation which will behind the scenes swap out the `.ma` for the `.mb` and cache out the realtime skeleton as an fbx to be applied in UE.