### PR TITLE
implement support for connecting from a `rig` to a `look` using an attribute in the rig as a way of defining the connections

### DIFF
--- a/openpype/hosts/maya/plugins/load/load_look.py
+++ b/openpype/hosts/maya/plugins/load/load_look.py
@@ -119,6 +119,9 @@ class LookLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
             nodes_by_id[lib.get_id(node)].append(node)
         lib.apply_attributes(attributes, nodes_by_id)
 
+        # Try to connect attributes from rig to shader nodes
+        lib.make_rig_to_shader_connections(nodes, shader_nodes)
+
     def _get_nodes_with_shader(self, shader_nodes):
         """
             Returns list of nodes belonging to specific shaders


### PR DESCRIPTION
## Changelog Description
Adds a function for creating connections between a `rig` and a `look`, sourced from a string attribute on a locator in the rig.

_**NOTE**: the locator and attribute names are hardcoded for our purposes at the moment, but we can easily expose that on an instance attribute instead to make it more flexible for the future._

The connection code runs in `lib.assign_look_by_version` and `load_look.update`.

## Testing notes:
1. Create and publish a look, making note of some shading node that you would like rigs to connect to, say `ramp1.noise` for example
2. Create and publish a rig, which has a transform and an attribute called `C_attributePublish_LOC.attributePublish`, which has a string of connection pairs of the form `{rig_attr}>{shading_attr}` separated by `;`s, without any namespaces. So for example `C_cog_CTL.noise>ramp1.noise;`.
3. Load the published rig and apply the published look, which will make the specified connection.
