### PR TITLE
Add support for replacing high resolution non-deforming geometries in a skeletal mesh with blueprints

### DIFF
--- a/openpype/hosts/unreal/plugins/load/load_layout.py
+++ b/openpype/hosts/unreal/plugins/load/load_layout.py
@@ -226,12 +226,11 @@ class LayoutLoader(plugin.Loader):
                     bindings.append(binding)
 
         if skeletal_mesh:
-            # Check if there are any blueprints in the Asset root folder
-            # (that's the folder that contains the version folders)
-            skeleton_parent_path = unreal.Paths.get_path(unreal.Paths.get_path(asset))
-            blueprints_in_skeleton_parent_path = unreal.AssetRegistryHelpers.\
+            # Check if there are any blueprints in the Asset version folder
+            skeleton_path = unreal.Paths.get_path(asset)
+            blueprints_in_skeleton_path = unreal.AssetRegistryHelpers.\
                 get_blueprint_assets(unreal.ARFilter(
-                    package_paths=[skeleton_parent_path]))
+                    package_paths=[skeleton_path]))
 
             # NOTE: worth considering whether we should do anything if there's
             # not blueprints in the path, as if that's the case, but there's
@@ -240,9 +239,9 @@ class LayoutLoader(plugin.Loader):
             # from blueprints that have been moved outside of the correct path,
             # but there is a chance that those are legitimate actors that
             # have been attached to the skeletal mesh.
-            if blueprints_in_skeleton_parent_path:
+            if blueprints_in_skeleton_path:
                 # If there are blueprints we want to attach them to the skeletal mesh
-                for bp_asset_data in blueprints_in_skeleton_parent_path:
+                for bp_asset_data in blueprints_in_skeleton_path:
                     # Check if a blueprint of this type is already attached as
                     # rebuilding the layout doesn't remove existing assets and
                     # readd them, but it uses the existing instances
@@ -255,7 +254,8 @@ class LayoutLoader(plugin.Loader):
 
                     # The attach socket is taken from the name of the blueprint
                     # like so: BP_{AssetName}_{SocketName}
-                    asset_name = unreal.Paths.get_base_filename(skeleton_parent_path)
+                    asset_name = unreal.Paths.get_base_filename(
+                        unreal.Paths.get_path(skeleton_path))
                     bp_tokens = str(bp_asset_data.asset_name).split(asset_name+'_',1)
                     if len(bp_tokens) != 2:
                         if bp_already_attached:

--- a/openpype/hosts/unreal/plugins/load/load_layout.py
+++ b/openpype/hosts/unreal/plugins/load/load_layout.py
@@ -258,10 +258,27 @@ class LayoutLoader(plugin.Loader):
                     asset_name = unreal.Paths.get_base_filename(skeleton_parent_path)
                     bp_tokens = str(bp_asset_data.asset_name).split(asset_name+'_',1)
                     if len(bp_tokens) != 2:
+                        if bp_already_attached:
+                            self.log.warning(f'Blueprint {bp_asset_data.package_name} '
+                                            'has the wrong naming convention, so '
+                                            'it is being removed from the layout.')
+
+                            if sequence:
+                                binding = sequence.find_binding_by_name(
+                                    child.get_actor_label())
+                                if binding.is_valid():
+                                    binding.remove()
+
+                            child.detach_from_actor()
+                            child.destroy_actor()
+
+                            continue
+
                         self.log.warning(f'Blueprint {bp_asset_data.package_name} '
                                           'has the wrong naming convention, so '
                                           'it is not being instantiated.')
                         continue
+
                     socket_name = bp_tokens[-1]
 
                     if bp_already_attached:

--- a/openpype/hosts/unreal/plugins/load/load_layout.py
+++ b/openpype/hosts/unreal/plugins/load/load_layout.py
@@ -266,12 +266,7 @@ class LayoutLoader(plugin.Loader):
 
                     if bp_already_attached:
                         # If a blueprint of this type is attached, first
-                        # ensure it's added to the sequence
-                        if sequence:
-                            bindings.append(sequence.add_possessable(child))
-                        actors.append(child)
-
-                        # Then ensure it's attached to the correct socket
+                        # ensure it's attached to the correct socket
                         attached_to_socket_name = str(child.get_attach_parent_socket_name())
                         if socket_name != attached_to_socket_name:
                             child.detach_from_actor()
@@ -280,6 +275,25 @@ class LayoutLoader(plugin.Loader):
                                 location_rule=unreal.AttachmentRule.SNAP_TO_TARGET,
                                 rotation_rule=unreal.AttachmentRule.SNAP_TO_TARGET,
                                 scale_rule=unreal.AttachmentRule.SNAP_TO_TARGET)
+
+                            old_label = child.get_actor_label()
+                            new_label = str(old_label).replace(
+                                attached_to_socket_name, socket_name)
+
+                            child.rename(new_label)
+                            child.set_actor_label(new_label)
+
+                            if sequence:
+                                # Remove old binding if it exists
+                                old_binding = sequence.find_binding_by_name(old_label)
+                                if old_binding.is_valid():
+                                    old_binding.remove()
+
+                        # Then ensure it's added to the sequence
+                        if sequence:
+                            bindings.append(sequence.add_possessable(child))
+
+                        actors.append(child)
 
                         # Carry on without creating a new blueprint instance
                         continue


### PR DESCRIPTION
## Changelog Description
Makes layout creation bring in any blueprints existing in the asset's version folder as _attached children_ to the skeletal mesh corresponding to that asset's version.

That way, heavy non-deforming geometries can be stripped out from the `.fbx` export and can be replaced with static meshes attached via blueprints and sockets.

Blueprints in version folders will be copied to new version folders upon their `.fbx` import, so blueprints are versioned, but asset artists do not have to create them manually for each new version.

## Testing notes:
1. Create any blueprint inside of an asset's skeletal mesh folder
2. Build a layout with that skeletal mesh as part of it, which will also bring in any blueprints from the version folder
