### PR TITLE
Support multiple layouts in maya to ue pipeline

### DIFF
--- a/openpype/hosts/unreal/plugins/load/load_animation.py
+++ b/openpype/hosts/unreal/plugins/load/load_animation.py
@@ -175,6 +175,9 @@ class AnimationFBXLoader(plugin.Loader):
         for h in hierarchy:
             hierarchy_dir = f"{hierarchy_dir}/{h}"
         hierarchy_dir = f"{hierarchy_dir}/{asset}"
+        layout = context.get('representation',{}).get('context',{}).get('layout',None)
+        if layout is not None:
+            hierarchy_dir = f"{hierarchy_dir}/{layout}"
         _filter = unreal.ARFilter(
             class_names=["World"],
             package_paths=[f"{hierarchy_dir}/"],

--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -836,6 +836,8 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
         # NOTE: Added to export namespace
         if repre.get("namespace"):
             repre_context["namespace"] = repre.get("namespace")
+        if repre.get("layout"):
+            repre_context["layout"] = repre.get("layout")
 
         repre_doc = new_representation_doc(
             repre["name"], version["_id"], repre_context, data, repre_id


### PR DESCRIPTION
## Changelog Description
This pull request implements support for multiple layouts in Unreal, meaning multiple layouts can be imported from Maya and treated separately in UE to ultimately be combined for rendering.

Animations have now been associated with a layout, so we can have multiple layouts and import the animation only in the specified one.

Supporting that has meant that the shot levels and sequences now have the `_layout{subset}` prefix e.g. `{SHOT}_layoutMain_map`, to differentiate between different layouts.

The cameras are NOT associated with layouts, so they are imported in all existing layouts, which means that we have multiple copies of the same camera in the shot levels, but since the name of the camera is the same we only have one instance in the sequencer.
