### PR TITLE
Introduce ep/scene/shot hierarchy in the "Animations" folder and remove duplication of names in layout filenames

### DIFF
--- a/openpype/hosts/unreal/plugins/load/load_animation.py
+++ b/openpype/hosts/unreal/plugins/load/load_animation.py
@@ -181,22 +181,21 @@ class AnimationFBXLoader(plugin.Loader):
         for h in hierarchy:
             hierarchy_dir = f"{hierarchy_dir}/{h}"
         hierarchy_dir = f"{hierarchy_dir}/{asset}"
-        print("before",hierarchy_dir)
-        '''
+
+        # Get the "layout" field from the published animation, as we support multiple
+        # layouts, so we need to know which layout to add this animation to
         layout = context.get('representation',{}).get('context',{}).get('layout',None)
         if layout is not None:
+            # Older publishes don't have the "layout" field, so this is for compatibility
             hierarchy_dir = f"{hierarchy_dir}/{layout}"
-            print("fishy...")
-        print("Looking for ",hierarchy_dir)
-        '''
-        #TODO: Ask Vasil whats this?
+
+        # Get all levels in the specified folder
         _filter = unreal.ARFilter(
             class_names=["World"],
             package_paths=[f"{hierarchy_dir}/"],
             recursive_paths=True)
         levels = ar.get_assets(_filter)
-        for level in levels:
-            print("FOUND",level)
+
         level = levels[0].get_asset().get_path_name()
         if not replacing_AYONs_level_hierarchy:
             unreal.EditorLevelLibrary.save_all_dirty_levels()

--- a/openpype/hosts/unreal/plugins/load/load_animation.py
+++ b/openpype/hosts/unreal/plugins/load/load_animation.py
@@ -195,6 +195,7 @@ class AnimationFBXLoader(plugin.Loader):
             package_paths=[f"{hierarchy_dir}/"],
             recursive_paths=True)
         levels = ar.get_assets(_filter)
+        for level in levels:
             print("FOUND",level)
         level = levels[0].get_asset().get_path_name()
         if not replacing_AYONs_level_hierarchy:

--- a/openpype/hosts/unreal/plugins/load/load_animation.py
+++ b/openpype/hosts/unreal/plugins/load/load_animation.py
@@ -162,9 +162,11 @@ class AnimationFBXLoader(plugin.Loader):
         asset = context.get('asset').get('name')
         suffix = "_CON"
         asset_name = f"{asset}_{name}" if asset else f"{name}"
+        scene_name = hierarchy[-1]
+        episode_name = hierarchy[-2]
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         asset_dir, container_name = tools.create_unique_asset_name(
-            f"{root}/Animations/{asset}/{name}", suffix="")
+            f"{root}/Animations/{episode_name}/{scene_name}/{asset}/{name}", suffix="")
 
         ar = unreal.AssetRegistryHelpers.get_asset_registry()
         _filter = unreal.ARFilter(

--- a/openpype/hosts/unreal/plugins/load/load_animation.py
+++ b/openpype/hosts/unreal/plugins/load/load_animation.py
@@ -181,17 +181,22 @@ class AnimationFBXLoader(plugin.Loader):
         for h in hierarchy:
             hierarchy_dir = f"{hierarchy_dir}/{h}"
         hierarchy_dir = f"{hierarchy_dir}/{asset}"
+        print("before",hierarchy_dir)
+        '''
         layout = context.get('representation',{}).get('context',{}).get('layout',None)
         if layout is not None:
             hierarchy_dir = f"{hierarchy_dir}/{layout}"
+            print("fishy...")
+        print("Looking for ",hierarchy_dir)
+        '''
+        #TODO: Ask Vasil whats this?
         _filter = unreal.ARFilter(
             class_names=["World"],
             package_paths=[f"{hierarchy_dir}/"],
             recursive_paths=True)
         levels = ar.get_assets(_filter)
-
+            print("FOUND",level)
         level = levels[0].get_asset().get_path_name()
-
         if not replacing_AYONs_level_hierarchy:
             unreal.EditorLevelLibrary.save_all_dirty_levels()
             unreal.EditorLevelLibrary.load_level(level)

--- a/openpype/hosts/unreal/plugins/load/load_layout.py
+++ b/openpype/hosts/unreal/plugins/load/load_layout.py
@@ -567,7 +567,6 @@ class LayoutLoader(plugin.Loader):
         return output
 
     def _process(self, lib_path, asset_dir, sequence, repr_loaded=None):
-        print("DERP A DERP")
         ar = unreal.AssetRegistryHelpers.get_asset_registry()
 
         with open(lib_path, "r") as fp:
@@ -785,7 +784,8 @@ class LayoutLoader(plugin.Loader):
             list(str): list of container content
         """
         data = get_current_project_settings()
-        create_sequences = True#data["unreal"]["level_sequences_for_layouts"]
+                                # v   the below is an AYON bundle setting, but we force it
+        create_sequences = True # data["unreal"]["level_sequences_for_layouts"]
         # Create directory for asset and Ayon container
         hierarchy = context.get('asset').get('data').get('parents')
         root = self.ASSET_ROOT

--- a/openpype/hosts/unreal/plugins/load/load_layout.py
+++ b/openpype/hosts/unreal/plugins/load/load_layout.py
@@ -567,6 +567,7 @@ class LayoutLoader(plugin.Loader):
         return output
 
     def _process(self, lib_path, asset_dir, sequence, repr_loaded=None):
+        print("DERP A DERP")
         ar = unreal.AssetRegistryHelpers.get_asset_registry()
 
         with open(lib_path, "r") as fp:
@@ -713,6 +714,7 @@ class LayoutLoader(plugin.Loader):
             animation_file = element.get('animation')
 
             if animation_file and skeleton:
+                raise NotImplementedError("Skeleton and Animation File Present in Layout.")
                 self._import_animation(
                     asset_dir, path, instance_name, skeleton, actors_dict,
                     animation_file, bindings_dict, sequence)
@@ -783,7 +785,7 @@ class LayoutLoader(plugin.Loader):
             list(str): list of container content
         """
         data = get_current_project_settings()
-        create_sequences = data["unreal"]["level_sequences_for_layouts"]
+        create_sequences = True#data["unreal"]["level_sequences_for_layouts"]
         # Create directory for asset and Ayon container
         hierarchy = context.get('asset').get('data').get('parents')
         root = self.ASSET_ROOT
@@ -794,7 +796,7 @@ class LayoutLoader(plugin.Loader):
             hierarchy_dir_list.append(hierarchy_dir)
         asset = context.get('asset').get('name')
         suffix = "_CON"
-        asset_name = f"{asset}_{name}" if asset else name
+        asset_name = name#f"{asset}_{name}" if asset else name
         tools = unreal.AssetToolsHelpers().get_asset_tools()
         ar = unreal.AssetRegistryHelpers.get_asset_registry()
 
@@ -804,7 +806,7 @@ class LayoutLoader(plugin.Loader):
         container_name += suffix
         EditorAssetLibrary.make_directory(asset_dir)
 
-        asset_subset = f'{asset}_{container_name[:-4]}'
+        asset_subset = name
 
         master_level = None
         shot = None


### PR DESCRIPTION
Animations are now stored in the `Ayon/Animations` folder like so:

```
- Ayon
  - Animations
    - Ep_101
      - 010
        - 010_010
          - animation for asset A in 010_010
          - animation for asset A in 010_010
          ..
```          

Additionally the bug with duplicate names in layouts e.g. `CY1_301_DON_020_020_CY1_301_DON_020_020_layout_multiMain_map` has been fixed now.

This is @tomPriceBz 's work, I am only merging it.