### PR TITLE
Update unreal loader to embed skeletal mesh inside blueprint.

### DIFF
--- a/openpype/hosts/unreal/plugins/load/load_animation.py
+++ b/openpype/hosts/unreal/plugins/load/load_animation.py
@@ -17,6 +17,7 @@ from openpype.pipeline import (
 )
 from openpype.hosts.unreal.api import plugin
 from openpype.hosts.unreal.api import pipeline as unreal_pipeline
+from openpype.hosts.unreal.plugins.load.load_skeletalmesh_fbx import clean_instance_name
 
 from openpype.hosts.unreal.plugins.load.load_layout import\
     replacing_AYONs_level_hierarchy
@@ -35,6 +36,12 @@ class AnimationFBXLoader(plugin.Loader):
         if not instance_data:
             raise RuntimeError('Unexpected error retrieving frame range data. '
                                'Please submit ticket with the full error.')
+
+        # Version check for 5.7+ BP wrapping
+        ue_version = unreal.SystemLibrary.get_engine_version().split('.')
+        ue_major = int(ue_version[0])
+        ue_minor = int(ue_version[1])
+        is5_7_or_later = ue_major == 5 and ue_minor >= 7
 
         # Set the Interchange.FeatureFlags.Import.FBX CVar to false, as most of the
         # settings below pertain to the old (before 5.5 i.e. before Interchange)
@@ -56,15 +63,35 @@ class AnimationFBXLoader(plugin.Loader):
             # actor = unreal.EditorLevelLibrary.get_actor_reference(actor_name)
             actors = unreal.EditorLevelLibrary.get_all_level_actors()
             for a in actors:
-                if a.get_class().get_name() != "SkeletalMeshActor":
-                    continue
+                if is5_7_or_later:
+                    # For 5.7+, we're looking for BP actors, not SkeletalMeshActor
+                    # Just match by label, don't filter by class
+                    if a.get_actor_label() == instance_name:
+                        actor = a
+                        break
+                else:
+                    # Original logic for pre-5.7
+                    if a.get_class().get_name() != "SkeletalMeshActor":
+                        continue
 
-                if a.get_actor_label() == instance_name:
-                    actor = a
-                    break
+                    if a.get_actor_label() == instance_name:
+                        actor = a
+                        break
             if not actor:
                 raise Exception(f'Could not find actor "{instance_name}" in Level ')
-            skeleton = actor.skeletal_mesh_component.skeletal_mesh.skeleton
+
+            # Get skeleton from the appropriate component
+            if is5_7_or_later:
+                # Find skeleton from named component
+                skeleton = None
+                for comp in actor.get_components_by_class(unreal.SkeletalMeshComponent):
+                    if "AssetSkeletalMesh" in comp.get_name():
+                        skeleton = comp.skeletal_mesh.skeleton
+                        break
+                if not skeleton:
+                    raise Exception(f'Could not find AssetSkeletalMesh component on actor "{instance_name}"')
+            else:
+                skeleton = actor.skeletal_mesh_component.skeletal_mesh.skeleton
             task.options.set_editor_property('skeleton', skeleton)
 
         if not actor:
@@ -147,10 +174,22 @@ class AnimationFBXLoader(plugin.Loader):
             animation.set_editor_property('root_motion_root_lock', unreal.RootMotionRootLock.REF_POSE)
             animation.set_editor_property('additive_anim_type', unreal.AdditiveAnimationType.AAT_NONE)
             animation.set_editor_property('interpolation', unreal.AnimInterpolationType.LINEAR)
-            actor.skeletal_mesh_component.set_editor_property(
-                'animation_mode', unreal.AnimationMode.ANIMATION_SINGLE_NODE)
-            actor.skeletal_mesh_component.animation_data.set_editor_property(
-                'anim_to_play', animation)
+
+            # Get the skeletal mesh component - for 5.7+ find by name, for pre-5.7 use direct property
+            skm_component = None
+            if is5_7_or_later:
+                for comp in actor.get_components_by_class(unreal.SkeletalMeshComponent):
+                    if "AssetSkeletalMesh" in comp.get_name():
+                        skm_component = comp
+                        break
+            else:
+                skm_component = actor.skeletal_mesh_component
+
+            if skm_component:
+                skm_component.set_editor_property(
+                    'animation_mode', unreal.AnimationMode.ANIMATION_SINGLE_NODE)
+                skm_component.animation_data.set_editor_property(
+                    'anim_to_play', animation)
 
         return animation
 
@@ -176,6 +215,12 @@ class AnimationFBXLoader(plugin.Loader):
         Returns:
             list(str): list of container content
         """
+        # Version check for 5.7+ BP wrapping
+        ue_version = unreal.SystemLibrary.get_engine_version().split('.')
+        ue_major = int(ue_version[0])
+        ue_minor = int(ue_version[1])
+        is5_7_or_later = ue_major == 5 and ue_minor >= 7
+
         # Always start by saving everything, so if we get an error or crash
         # during loading we have saved our changes, but also to make sure
         # that people push EVERYTHING on perforce and never have to
@@ -240,8 +285,9 @@ class AnimationFBXLoader(plugin.Loader):
         instance_name = context.get('representation',{}).get('context',{}).get('namespace',None)
         if instance_name == None:
             raise AttributeError("Namespace not found in representation publish, unable to determine which actor to apply animation")
-        # Remove colon
+        # Remove colon and clean subset name from instance name
         instance_name = instance_name.replace(":","")
+        instance_name = clean_instance_name(instance_name)
 
         EditorAssetLibrary.make_directory(asset_dir)
         path = self.filepath_from_context(context)
@@ -262,9 +308,19 @@ class AnimationFBXLoader(plugin.Loader):
         for s in sequences:
             sequence = ar.get_asset_by_object_path(s).get_asset()
 
-            possessables = [
-                p for p in sequence.get_possessables()
-                if p.get_display_name() == instance_name]
+            if is5_7_or_later:
+                # Look for component possessable (added by layout loader)
+                # In 5.7+ the animation binds to the AssetSkeletalMesh component
+                possessables = [
+                    p for p in sequence.get_possessables()
+                    if "AssetSkeletalMesh" in str(p.get_display_name())
+                       and str(p.get_parent().get_display_name()) == instance_name
+                ]
+            else:
+                # Original: look for actor possessable
+                possessables = [
+                    p for p in sequence.get_possessables()
+                    if p.get_display_name() == instance_name]
 
             if possessables == []:
                 raise AttributeError('No Actor with Label "{ns}" found in Level, Ensure Actor exists before applying animation'.format(ns=instance_name))

--- a/openpype/hosts/unreal/plugins/load/load_layout.py
+++ b/openpype/hosts/unreal/plugins/load/load_layout.py
@@ -31,6 +31,9 @@ from openpype.pipeline.context_tools import get_current_project_asset
 from openpype.settings import get_current_project_settings
 from openpype.hosts.unreal.api import plugin
 
+import re
+from openpype.hosts.unreal.plugins.load.load_skeletalmesh_fbx import get_blueprint_name, clean_instance_name
+
 from openpype.hosts.unreal.api import pipeline
 importlib.reload(pipeline)
 from openpype.hosts.unreal.api.pipeline import (
@@ -187,13 +190,44 @@ class LayoutLoader(plugin.Loader):
     def _process_family(
         self, assets, class_name, transform, basis, sequence, inst_name=None
     ):
+        # Version check for 5.7+ BP wrapping
+        ue_version = unreal.SystemLibrary.get_engine_version().split('.')
+        ue_major = int(ue_version[0])
+        ue_minor = int(ue_version[1])
+        is5_7_or_later = ue_major == 5 and ue_minor >= 7
+
         ar = unreal.AssetRegistryHelpers.get_asset_registry()
         actors = []
         bindings = []
         skeletal_mesh = None
+
+        # For 5.7+, when handling rig family, look for Blueprint instead of SkeletalMesh
+        target_class_name = class_name
+        expected_bp_name = None
+        if is5_7_or_later and class_name == 'SkeletalMesh':
+            target_class_name = 'Blueprint'
+            # Derive expected BP name from the container's asset metadata
+            # to avoid matching old copied BPs from previous versions
+            for a in assets:
+                obj_check = ar.get_asset_by_object_path(a).get_asset()
+                if obj_check and obj_check.get_class().get_name() == 'AyonAssetContainer':
+                    asset_folder_name = EditorAssetLibrary.get_metadata_tag(
+                        obj_check, 'asset')
+                    namespace = EditorAssetLibrary.get_metadata_tag(
+                        obj_check, 'namespace')
+                    if asset_folder_name and namespace:
+                        version_match = re.search(r'_v(\d+)$', namespace)
+                        if version_match:
+                            expected_bp_name = get_blueprint_name(
+                                asset_folder_name, int(version_match.group(1)))
+                    break
+
         for asset in assets:
             obj = ar.get_asset_by_object_path(asset).get_asset()
-            if obj and obj.get_class().get_name() == class_name:
+            if obj and obj.get_class().get_name() == target_class_name:
+                # 5.7+: Only match the specific wrapper Blueprint (BP_AssetName)
+                if expected_bp_name and obj.get_name() != expected_bp_name:
+                    continue
 
                 t = self._transform_from_basis(transform, basis,swap_axis=True)
                 actor = None
@@ -207,8 +241,8 @@ class LayoutLoader(plugin.Loader):
                         obj, t.translation
                     )
                     actor.set_actor_label(inst_name)
-                elif actor.static_class().get_name() == 'SkeletalMeshActor':
-                    # Ensure the actor is using the skeletal mesh specified
+                elif not is5_7_or_later and actor.static_class().get_name() == 'SkeletalMeshActor':
+                    # Pre-5.7: Ensure the actor is using the skeletal mesh specified
                     # by the provided `asset`, as a rig swap in Maya
                     # only changes the representation and nothing else
                     # so we can't just rely on the name
@@ -228,9 +262,10 @@ class LayoutLoader(plugin.Loader):
 
 
                 if class_name == 'SkeletalMesh':
-                    skm_comp = actor.get_editor_property(
-                        'skeletal_mesh_component')
-                    skm_comp.set_bounds_scale(10.0)
+                    if not is5_7_or_later:
+                        skm_comp = actor.get_editor_property(
+                            'skeletal_mesh_component')
+                        skm_comp.set_bounds_scale(10.0)
                     skeletal_mesh = actor
                 actors.append(actor)
 
@@ -245,91 +280,159 @@ class LayoutLoader(plugin.Loader):
                     if not binding:
                         binding = sequence.add_possessable(actor)
 
+                    # 5.7+: Also add component binding for the SkeletalMeshComponent
+                    # so animations can bind to it
+                    if is5_7_or_later and class_name == 'SkeletalMesh':
+                        for comp in actor.get_components_by_class(unreal.SkeletalMeshComponent):
+                            if "AssetSkeletalMesh" in comp.get_name():
+                                component_binding = sequence.add_possessable(comp)
+                                bindings.append(component_binding)
+                                break
+
                     bindings.append(binding)
 
         if skeletal_mesh:
-            # Check if there are any blueprints in the Asset version folder
-            skeleton_path = unreal.Paths.get_path(asset)
-            blueprints_in_skeleton_path = unreal.AssetRegistryHelpers.\
-                get_blueprint_assets(unreal.ARFilter(
-                    package_paths=[skeleton_path]))
+            if is5_7_or_later:
+                # 5.7+: BP attachment logic needs rework for new architecture
+                # where we use BP_AssetName Blueprint actors instead of SkeletalMeshActor
+                pass
+            else:
+                # Pre-5.7: Keep existing BP attachment and onLayoutInit logic
+                # Check if there are any blueprints in the Asset version folder
+                skeleton_path = unreal.Paths.get_path(asset)
+                blueprints_in_skeleton_path = unreal.AssetRegistryHelpers.\
+                    get_blueprint_assets(unreal.ARFilter(
+                        package_paths=[skeleton_path]))
 
-            # NOTE: worth considering whether we should do anything if there's
-            # not blueprints in the path, as if that's the case, but there's
-            # some attached actors, there's an argument to be made to
-            # unattach and destroy those actors, as they are _likely_ coming
-            # from blueprints that have been moved outside of the correct path,
-            # but there is a chance that those are legitimate actors that
-            # have been attached to the skeletal mesh.
-            #
-            # If there are blueprints we want to attach them to the skeletal mesh
-            for bp_asset_data in blueprints_in_skeleton_path:
-                # Check if a blueprint of this type is already attached as
-                # rebuilding the layout doesn't remove existing assets and
-                # readd them, but it uses the existing instances
-                bp_asset_data_split_path = str(bp_asset_data.package_name).split('/')
-                found_actor = None
-                for child in skeletal_mesh.get_attached_actors():
-                    child_path = child.get_class().get_class_path_name().package_name
-                    child_split_path = str(child_path).split('/')
+                # NOTE: worth considering whether we should do anything if there's
+                # not blueprints in the path, as if that's the case, but there's
+                # some attached actors, there's an argument to be made to
+                # unattach and destroy those actors, as they are _likely_ coming
+                # from blueprints that have been moved outside of the correct path,
+                # but there is a chance that those are legitimate actors that
+                # have been attached to the skeletal mesh.
+                #
+                # If there are blueprints we want to attach them to the skeletal mesh
+                for bp_asset_data in blueprints_in_skeleton_path:
+                    # Check if a blueprint of this type is already attached as
+                    # rebuilding the layout doesn't remove existing assets and
+                    # readd them, but it uses the existing instances
+                    bp_asset_data_split_path = str(bp_asset_data.package_name).split('/')
+                    found_actor = None
+                    for child in skeletal_mesh.get_attached_actors():
+                        child_path = child.get_class().get_class_path_name().package_name
+                        child_split_path = str(child_path).split('/')
 
-                    if len(child_split_path) != len(bp_asset_data_split_path):
-                        continue
+                        if len(child_split_path) != len(bp_asset_data_split_path):
+                            continue
 
-                    # Check if this is the same blueprint, but from different
-                    # versions of the asset, where only the second to last
-                    # token in the path will be different
-                    differences = [(a != b) for a,b in zip(bp_asset_data_split_path,
-                                                           child_split_path)]
-                    if sum(differences) == 1 and differences[-2]:
-                        # Delete the existing blueprint, as we should replace it with
-                        # the one from the new version of the asset
-                        if sequence:
-                            binding = sequence.find_binding_by_name(
-                                child.get_actor_label())
-                            if binding.is_valid():
-                                binding.remove()
-
-                        self.log.warning(
-                            f'{child.get_actor_label()} is from an older version.'
-                             ' of the asset, so it is being deleted to be replaced'
-                             ' with its new version.')
-
-                        child.detach_from_actor()
-                        child.destroy_actor()
-
-                        continue
-
-                    # Otherwise let's just check if this is the same blueprint, in
-                    # which case we have found a match (NOTE: this does not support
-                    # multiples of the same BP being attached, but that is not to spec)
-                    if child_path == bp_asset_data.package_name:
-                        found_actor = child
-
-                if found_actor is not None:
-                    onLayoutInit_ran = False
-                    try:
-                        found_actor.call_method('onLayoutInit')
-                        onLayoutInit_ran = True
-                    except Exception as e:
-                        if 'Failed to find function \'onLayoutInit\'' in str(e):
-                            # If an attached bp doesn't have the `onLayoutInit`
-                            # method defined, it means it has been removed
-                            # after the bp has been attached and since it is
-                            # now unclear where that bp should be attached,
-                            # we remove it from the level
+                        # Check if this is the same blueprint, but from different
+                        # versions of the asset, where only the second to last
+                        # token in the path will be different
+                        differences = [(a != b) for a,b in zip(bp_asset_data_split_path,
+                                                               child_split_path)]
+                        if sum(differences) == 1 and differences[-2]:
+                            # Delete the existing blueprint, as we should replace it with
+                            # the one from the new version of the asset
                             if sequence:
                                 binding = sequence.find_binding_by_name(
-                                    found_actor.get_actor_label())
+                                    child.get_actor_label())
                                 if binding.is_valid():
                                     binding.remove()
 
                             self.log.warning(
-                                f'{found_actor.get_actor_label()} no longer implements '
-                                 'the `onLayoutInit` method, so it is removed.')
+                                f'{child.get_actor_label()} is from an older version.'
+                                 ' of the asset, so it is being deleted to be replaced'
+                                 ' with its new version.')
 
-                            found_actor.detach_from_actor()
-                            found_actor.destroy_actor()
+                            child.detach_from_actor()
+                            child.destroy_actor()
+
+                            continue
+
+                        # Otherwise let's just check if this is the same blueprint, in
+                        # which case we have found a match (NOTE: this does not support
+                        # multiples of the same BP being attached, but that is not to spec)
+                        if child_path == bp_asset_data.package_name:
+                            found_actor = child
+
+                    if found_actor is not None:
+                        onLayoutInit_ran = False
+                        try:
+                            found_actor.call_method('onLayoutInit')
+                            onLayoutInit_ran = True
+                        except Exception as e:
+                            if 'Failed to find function \'onLayoutInit\'' in str(e):
+                                # If an attached bp doesn't have the `onLayoutInit`
+                                # method defined, it means it has been removed
+                                # after the bp has been attached and since it is
+                                # now unclear where that bp should be attached,
+                                # we remove it from the level
+                                if sequence:
+                                    binding = sequence.find_binding_by_name(
+                                        found_actor.get_actor_label())
+                                    if binding.is_valid():
+                                        binding.remove()
+
+                                self.log.warning(
+                                    f'{found_actor.get_actor_label()} no longer implements '
+                                     'the `onLayoutInit` method, so it is removed.')
+
+                                found_actor.detach_from_actor()
+                                found_actor.destroy_actor()
+                                continue
+                            else:
+                                raise e
+
+                        if onLayoutInit_ran:
+                            # onLayoutInit uses snap to target, but since the sockets
+                            # coming from Maya are flipped in X, let's solve that by
+                            # flipping here.
+                            # NOTE: it would be way better to do this in the rigs,
+                            #       but there's a lot of published ones already, so
+                            #       we solve it on loading
+                            child.add_actor_local_transform(
+                                unreal.Transform(scale=[-1,1,1]),
+                                False, False)
+                            unreal.log_warning('layout loading: flipping BP -1 in X after '
+                                               '`onLayoutInit` to account for socket '
+                                               'transform on ' + str(child))
+
+                        # Then ensure it's added to the sequence
+                        if sequence:
+                            bindings.append(sequence.add_possessable(child))
+
+                        actors.append(child)
+
+                        # Carry on without creating a new blueprint instance
+                        continue
+
+                    # Create actor of the specified blueprint type
+                    skeleton_bp_actor = EditorLevelLibrary.spawn_actor_from_object(
+                        bp_asset_data.get_asset(), unreal.Vector())
+
+                    # Attach it to our skeletal mesh, where the socket and the
+                    # rules don't matter, as we then call the `onLayoutInit`
+                    # method of the blueprint which we expect to handle the
+                    # attachment properly
+                    skeleton_bp_actor.attach_to_actor(skeletal_mesh,
+                        socket_name='None',
+                        location_rule=unreal.AttachmentRule.SNAP_TO_TARGET,
+                        rotation_rule=unreal.AttachmentRule.SNAP_TO_TARGET,
+                        scale_rule=unreal.AttachmentRule.SNAP_TO_TARGET)
+
+                    onLayoutInit_ran = False
+                    try:
+                        skeleton_bp_actor.call_method('onLayoutInit')
+                        onLayoutInit_ran = True
+                    except Exception as e:
+                        if 'Failed to find function \'onLayoutInit\'' in str(e):
+                            bp_class_path = bp_asset_data.package_name
+                            self.log.warning(f'Blueprint {bp_class_path} does not '
+                                              'implement the `onLayoutInit` '
+                                              'function, so it is not being attached.')
+                            skeleton_bp_actor.detach_from_actor()
+                            skeleton_bp_actor.destroy_actor()
                             continue
                         else:
                             raise e
@@ -341,72 +444,19 @@ class LayoutLoader(plugin.Loader):
                         # NOTE: it would be way better to do this in the rigs,
                         #       but there's a lot of published ones already, so
                         #       we solve it on loading
-                        child.add_actor_local_transform(
+                        skeleton_bp_actor.add_actor_local_transform(
                             unreal.Transform(scale=[-1,1,1]),
                             False, False)
                         unreal.log_warning('layout loading: flipping BP -1 in X after '
-                                           '`onLayoutInit` to account for socket '
-                                           'transform on ' + str(child))
+                                            '`onLayoutInit` to account for socket '
+                                            'transform on ' + str(skeleton_bp_actor))
 
-                    # Then ensure it's added to the sequence
+                    # Add blueprint to sequence and store it in actors and bindings,
+                    # even though they are only needed for importing animation
+                    # which this blueprint will never have
+                    actors.append(skeleton_bp_actor)
                     if sequence:
-                        bindings.append(sequence.add_possessable(child))
-
-                    actors.append(child)
-
-                    # Carry on without creating a new blueprint instance
-                    continue
-
-                # Create actor of the specified blueprint type
-                skeleton_bp_actor = EditorLevelLibrary.spawn_actor_from_object(
-                    bp_asset_data.get_asset(), unreal.Vector())
-
-                # Attach it to our skeletal mesh, where the socket and the
-                # rules don't matter, as we then call the `onLayoutInit`
-                # method of the blueprint which we expect to handle the
-                # attachment properly
-                skeleton_bp_actor.attach_to_actor(skeletal_mesh,
-                    socket_name='None',
-                    location_rule=unreal.AttachmentRule.SNAP_TO_TARGET,
-                    rotation_rule=unreal.AttachmentRule.SNAP_TO_TARGET,
-                    scale_rule=unreal.AttachmentRule.SNAP_TO_TARGET)
-
-                onLayoutInit_ran = False
-                try:
-                    skeleton_bp_actor.call_method('onLayoutInit')
-                    onLayoutInit_ran = True
-                except Exception as e:
-                    if 'Failed to find function \'onLayoutInit\'' in str(e):
-                        bp_class_path = bp_asset_data.package_name
-                        self.log.warning(f'Blueprint {bp_class_path} does not '
-                                          'implement the `onLayoutInit` '
-                                          'function, so it is not being attached.')
-                        skeleton_bp_actor.detach_from_actor()
-                        skeleton_bp_actor.destroy_actor()
-                        continue
-                    else:
-                        raise e
-
-                if onLayoutInit_ran:
-                    # onLayoutInit uses snap to target, but since the sockets
-                    # coming from Maya are flipped in X, let's solve that by
-                    # flipping here.
-                    # NOTE: it would be way better to do this in the rigs,
-                    #       but there's a lot of published ones already, so
-                    #       we solve it on loading
-                    skeleton_bp_actor.add_actor_local_transform(
-                        unreal.Transform(scale=[-1,1,1]),
-                        False, False)
-                    unreal.log_warning('layout loading: flipping BP -1 in X after '
-                                        '`onLayoutInit` to account for socket '
-                                        'transform on ' + str(skeleton_bp_actor))
-
-                # Add blueprint to sequence and store it in actors and bindings,
-                # even though they are only needed for importing animation
-                # which this blueprint will never have
-                actors.append(skeleton_bp_actor)
-                if sequence:
-                    bindings.append(sequence.add_possessable(skeleton_bp_actor))
+                        bindings.append(sequence.add_possessable(skeleton_bp_actor))
 
         return actors, bindings
 
@@ -668,7 +718,7 @@ class LayoutLoader(plugin.Loader):
                 for instance in instances:
                     transform = instance.get('transform_matrix')
                     basis = instance.get('basis')
-                    inst = instance.get('instance_name')
+                    inst = clean_instance_name(instance.get('instance_name'))
 
                     actors = []
                     if family == 'model':

--- a/openpype/hosts/unreal/plugins/load/load_skeletalmesh_fbx.py
+++ b/openpype/hosts/unreal/plugins/load/load_skeletalmesh_fbx.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Load Skeletal Meshes form FBX."""
 import os
+import re
 
 from openpype.pipeline import (
     get_representation_path,
@@ -9,6 +10,97 @@ from openpype.pipeline import (
 from openpype.hosts.unreal.api import plugin
 from openpype.hosts.unreal.api import pipeline as unreal_pipeline
 import unreal  # noqa
+
+BOILERPLATE_BP_PATH = "/Game/Utilities/UtilityBlueprints/BP_BZAsset_BoilerPlate"
+
+
+def get_blueprint_name(asset_name, version):
+    """Add BP_ prefix and version suffix to asset name."""
+    return f"BP_{asset_name}_v{version:03d}"
+
+
+def clean_instance_name(instance_name):
+    """Strip subset name and trailing underscore from instance name.
+
+    Transforms 'PRP_ArcticPole_rigMain_01_' to 'PRP_ArcticPole_01'.
+    Subset names are camelCase (start with lowercase letter).
+    """
+    return re.sub(r'_([a-z][a-zA-Z0-9]*)_(\d+)_?$', r'_\2', instance_name)
+
+
+def set_skeletal_mesh_on_blueprint(bp_asset, skeletal_mesh):
+    """Set the skeletal mesh on a Blueprint's inherited AssetSkeletalMesh component.
+
+    Uses SubobjectDataSubsystem to find the inherited SkeletalMeshComponent,
+    then SubobjectDataBlueprintFunctionLibrary.get_object_for_blueprint() to
+    get the child-specific override (not the parent's shared template).
+    """
+    bp_name = bp_asset.get_name()
+    subsystem = unreal.get_engine_subsystem(unreal.SubobjectDataSubsystem)
+    if not subsystem:
+        print(f"[BP Wrapper] ERROR: Could not get SubobjectDataSubsystem")
+        return False
+
+    lib = unreal.SubobjectDataBlueprintFunctionLibrary
+    handles = subsystem.k2_gather_subobject_data_for_blueprint(context=bp_asset)
+
+    # Find the AssetSkeletalMesh SubobjectData
+    target_data = None
+    for handle in handles:
+        data = subsystem.k2_find_subobject_data_from_handle(handle)
+        if not data:
+            continue
+        export = data.export_text()
+        if 'SkeletalMeshComponent' in export and 'AssetSkeletalMesh' in export:
+            target_data = data
+            break
+
+    if not target_data:
+        print(f"[BP Wrapper] ERROR: No AssetSkeletalMesh component found on {bp_name}")
+        return False
+
+    # get_object_for_blueprint returns the child BP's override component,
+    # not the parent's shared template
+    child_comp = lib.get_object_for_blueprint(target_data, bp_asset)
+    if not child_comp:
+        print(f"[BP Wrapper] ERROR: get_object_for_blueprint returned None for {bp_name}")
+        return False
+
+    child_comp.set_editor_property('skeletal_mesh_asset', skeletal_mesh)
+    bp_asset.modify()
+    print(f"[BP Wrapper] Set skeletal mesh on {bp_name}")
+    return True
+
+
+def validate_blueprint_has_component(bp_asset):
+    """
+    Check if a Blueprint has the AssetSkeletalMesh component.
+
+    Args:
+        bp_asset: The Blueprint asset to validate
+
+    Returns:
+        bool: True if the component exists, False otherwise
+    """
+    try:
+        subsystem = unreal.get_engine_subsystem(unreal.SubobjectDataSubsystem)
+        if not subsystem:
+            return False
+
+        handles = subsystem.k2_gather_subobject_data_for_blueprint(context=bp_asset)
+
+        for handle in handles:
+            data = subsystem.k2_find_subobject_data_from_handle(handle)
+            if not data:
+                continue
+
+            export = data.export_text()
+            if 'SkeletalMeshComponent' in export and 'AssetSkeletalMesh' in export:
+                return True
+
+        return False
+    except:
+        return False
 
 
 class SkeletalMeshFBXLoader(plugin.Loader):
@@ -56,6 +148,11 @@ class SkeletalMeshFBXLoader(plugin.Loader):
         version = context.get('version').get('name')
         tools = unreal.AssetToolsHelpers().get_asset_tools()
 
+        # Version check for 5.7+ BP wrapping
+        ue_version = unreal.SystemLibrary.get_engine_version().split('.')
+        ue_major = int(ue_version[0])
+        ue_minor = int(ue_version[1])
+        is5_7_or_later = ue_major == 5 and ue_minor >= 7
 
         import pprint
 
@@ -166,7 +263,7 @@ class SkeletalMeshFBXLoader(plugin.Loader):
                 newly_imported_SKM.set_editor_property("nanite_settings", nanite_settings)
 
                 # Save the asset directly, we are directly after the asset
-                # I am considering not doing this save since we're not 
+                # I am considering not doing this save since we're not
                 # directly saving the skeletal mesh either, inconsistent
                 unreal.EditorAssetLibrary.save_loaded_asset(newly_imported_SKM)
 
@@ -196,15 +293,63 @@ class SkeletalMeshFBXLoader(plugin.Loader):
                     latest_version_folder = package_parent
 
             if latest_version_folder:
-                blueprints_to_copy = unreal.AssetRegistryHelpers.\
-                    get_blueprint_assets(unreal.ARFilter(
-                        package_paths=[latest_version_folder]))
+                if is5_7_or_later:
+                    # 5.7+: Find previous version's BP and copy with new version suffix
+                    prev_version_match = re.search(r'_v(\d+)$', latest_version_folder)
+                    if prev_version_match:
+                        prev_version = int(prev_version_match.group(1))
+                        prev_bp_name = get_blueprint_name(asset, prev_version)
+                        new_bp_name = get_blueprint_name(asset, version)
+                        prev_bp_path = f"{latest_version_folder}/{prev_bp_name}"
+                        if unreal.EditorAssetLibrary.does_asset_exist(prev_bp_path):
+                            prev_bp = unreal.EditorAssetLibrary.load_asset(prev_bp_path)
+                            if prev_bp and validate_blueprint_has_component(prev_bp):
+                                unreal.EditorAssetLibrary.duplicate_asset(
+                                    prev_bp_path,
+                                    f"{asset_dir}/{new_bp_name}")
+                else:
+                    # Pre-5.7: Copy all BPs from previous version
+                    blueprints_to_copy = unreal.AssetRegistryHelpers.\
+                        get_blueprint_assets(unreal.ARFilter(
+                            package_paths=[latest_version_folder]))
 
-                for bp_asset_data in blueprints_to_copy:
-                    bp_name = unreal.Paths.get_clean_filename(bp_asset_data.package_name)
+                    for bp_asset_data in blueprints_to_copy:
+                        bp_name_to_copy = unreal.Paths.get_clean_filename(bp_asset_data.package_name)
+                        unreal.EditorAssetLibrary.duplicate_asset(
+                            str(bp_asset_data.package_name),
+                            unreal.Paths.combine([asset_dir, bp_name_to_copy]))
+
+            # UE 5.7+: Create or update Blueprint wrapper for the skeletal mesh
+            if is5_7_or_later and newly_imported_SKM:
+                bp_name = get_blueprint_name(asset, version)
+                bp_path = f"{asset_dir}/{bp_name}"
+
+                # Check if BP exists and is valid
+                bp_exists = unreal.EditorAssetLibrary.does_asset_exist(bp_path)
+                bp_needs_recreation = False
+
+                if bp_exists:
+                    # Validate the existing BP has the AssetSkeletalMesh component
+                    bp_asset = unreal.EditorAssetLibrary.load_asset(bp_path)
+                    if not bp_asset or not validate_blueprint_has_component(bp_asset):
+                        print(f"[BP Wrapper] Existing BP at {bp_path} is invalid. Recreating from boilerplate.")
+                        bp_needs_recreation = True
+
+                if not bp_exists or bp_needs_recreation:
+                    if bp_needs_recreation:
+                        unreal.EditorAssetLibrary.delete_asset(bp_path)
+                    # Copy from boilerplate
+                    print(f"[BP Wrapper] Creating BP from boilerplate: {bp_path}")
                     unreal.EditorAssetLibrary.duplicate_asset(
-                        str(bp_asset_data.package_name),
-                        unreal.Paths.combine([asset_dir, bp_name]))
+                        BOILERPLATE_BP_PATH,
+                        bp_path
+                    )
+
+                # Load BP and set the skeletal mesh
+                bp_asset = unreal.EditorAssetLibrary.load_asset(bp_path)
+                if bp_asset:
+                    set_skeletal_mesh_on_blueprint(bp_asset, newly_imported_SKM)
+                    unreal.EditorAssetLibrary.save_asset(bp_path)
 
             # Create Asset Container
             if not unreal.EditorAssetLibrary.does_asset_exist(
@@ -250,6 +395,12 @@ class SkeletalMeshFBXLoader(plugin.Loader):
         return asset_content
 
     def update(self, container, representation):
+        # Version check for 5.7+ BP wrapping
+        ue_version = unreal.SystemLibrary.get_engine_version().split('.')
+        ue_major = int(ue_version[0])
+        ue_minor = int(ue_version[1])
+        is5_7_or_later = ue_major == 5 and ue_minor >= 7
+
         # Check if the target version had nanite enabled before we update
         existing_has_nanite_enabled = True
         last_version_skm = unreal.load_asset(container["namespace"] + '/' + container["asset_name"])
@@ -304,7 +455,7 @@ class SkeletalMeshFBXLoader(plugin.Loader):
         unreal.AssetToolsHelpers.get_asset_tools().import_asset_tasks([task])  # noqa: E501
 
         container_path = "{}/{}".format(container["namespace"],
-                                        container["objectName"])        
+                                        container["objectName"])
 
         # Load the asset we just imported
         newly_imported_SKM = unreal.load_asset(container["namespace"] + '/' + container["asset_name"])
@@ -317,9 +468,24 @@ class SkeletalMeshFBXLoader(plugin.Loader):
             newly_imported_SKM.set_editor_property("nanite_settings", nanite_settings)
 
             # Save the asset directly, we are directly after the asset
-            # I am considering not doing this save since we're not 
+            # I am considering not doing this save since we're not
             # directly saving the skeletal mesh either, inconsistent
             unreal.EditorAssetLibrary.save_loaded_asset(newly_imported_SKM)
+
+            # UE 5.7+: Update Blueprint wrapper's SkeletalMeshComponent
+            if is5_7_or_later:
+                asset_name = container.get("asset", "")
+                version_match = re.search(r'_v(\d+)$', destination_path)
+                if version_match:
+                    ver = int(version_match.group(1))
+                    bp_name = get_blueprint_name(asset_name, ver)
+                    bp_path = f"{destination_path}/{bp_name}"
+
+                    if unreal.EditorAssetLibrary.does_asset_exist(bp_path):
+                        bp_asset = unreal.EditorAssetLibrary.load_asset(bp_path)
+                        if bp_asset:
+                            set_skeletal_mesh_on_blueprint(bp_asset, newly_imported_SKM)
+                            unreal.EditorAssetLibrary.save_asset(bp_path)
 
         # update metadata
         unreal_pipeline.imprint(


### PR DESCRIPTION
## Changelog Description
At the request of Assets and Production, we now embed the skeletal mesh for an imported asset into a container Blueprint which inherits from base BZ_Asset. This change relies on the files:

/Game/Utilities/UtilityBlueprints/BZ_Asset
/Game/Utilities/UtilityBlueprints/BP_BZAsset_BoilerPlate

These are hardcoded paths and potentially dangerous - this might want reworking.

This affords us a more polymorphic, 'Game Engine' friendly way of handling assets, we can now call agnostic methods on assets during setup, begin play and event tick. 

Where previously we would add sub static mesh, lights and other components into a blueprint and attach those to the raw skeletal mesh actor in the scene via socket, leading to editor and runtime problems when using 'get parent' blueprint nodes before UE5 parent hierarchies are formalized at begin play, we now embed these into the Asset blueprint itself, socketing onto the inherited skeletal mesh component and exposing them directly to our per-asset logic.

Similar to the legacy method, this does previous version asset checks, copying existing valid BPs and updating SKM references, duplicating the boilerplate if no valid asset BP exists (by name and type). The blueprint asset name is also implicitly versioned to match its container folder from ayon for better legibility directly in the scene.

These changes are also reflected in the load layout and load/update animation phases, bindings properly target the subcomponent SKM and follow new naming conventions. Allowing us to use the built int 'replace actor' via the scene outliner to override asset versions directly in engine for rapid testing outside of Ayon if necessary (same as legacy).

All changes are strictly gated behind a major and minor version check, all UE 5.7 and later will use this new method, all previous versions will use the legacy, direct skeletal mesh method.
