### PR TITLE
Integrated socket flip fixes for fbx SKM and animation imports.

### DIFF
--- a/openpype/hosts/unreal/plugins/load/load_animation.py
+++ b/openpype/hosts/unreal/plugins/load/load_animation.py
@@ -22,6 +22,28 @@ from openpype.hosts.unreal.plugins.load.load_skeletalmesh_fbx import clean_insta
 from openpype.hosts.unreal.plugins.load.load_layout import\
     replacing_AYONs_level_hierarchy
 
+SOCKET_BONE_PREFIX = "_sock_"   # all sockets are confirmed to start with this
+SOCKET_FLIP_SCALE = (1, -1, -1)
+
+
+def _flip_socket_bones_on_anim(anim_sequence_path):
+    """Mirror socket bones on a freshly (re)imported AnimSequence.
+
+    Automated equivalent of the right-click 'set anim scale' scripted asset
+    action: scales every bone track whose name starts with `_sock_` by
+    `(1, -1, -1)`, adding a track for matching bones that aren't animated yet.
+    Imported locally and wrapped so a failure only logs — it must never abort
+    the animation import pipeline.
+    """
+    try:
+        import skeletal_mesh_helpers  # lives in /Content/Python
+        skeletal_mesh_helpers.set_anim_scale_for_bones_matching(
+            anim_sequence_path, SOCKET_BONE_PREFIX,
+            scale=SOCKET_FLIP_SCALE, prefix_only=True,
+            add_track_if_missing=True)
+    except Exception as exc:
+        unreal.log_warning(f"[Socket Flip] Skipped {anim_sequence_path}: {exc}")
+
 
 class AnimationFBXLoader(plugin.Loader):
     """Load Unreal SkeletalMesh from FBX."""
@@ -190,6 +212,9 @@ class AnimationFBXLoader(plugin.Loader):
                     'animation_mode', unreal.AnimationMode.ANIMATION_SINGLE_NODE)
                 skm_component.animation_data.set_editor_property(
                     'anim_to_play', animation)
+
+            # Mirror-flip socket bones (`_sock_` prefix) on the fresh clip
+            _flip_socket_bones_on_anim(animation.get_path_name())
 
         return animation
 
@@ -482,6 +507,12 @@ class AnimationFBXLoader(plugin.Loader):
 
         # do import fbx and replace existing data
         unreal.AssetToolsHelpers.get_asset_tools().import_asset_tasks([task])
+
+        # Mirror-flip socket bones (`_sock_` prefix); reimport replaces the
+        # clip's tracks, so this has to run on update too
+        _flip_socket_bones_on_anim(
+            container["namespace"] + '/' + container["asset_name"])
+
         container_path = f'{container["namespace"]}/{container["objectName"]}'
         # update metadata
         unreal_pipeline.imprint(

--- a/openpype/hosts/unreal/plugins/load/load_skeletalmesh_fbx.py
+++ b/openpype/hosts/unreal/plugins/load/load_skeletalmesh_fbx.py
@@ -13,6 +13,26 @@ import unreal  # noqa
 
 BOILERPLATE_BP_PATH = "/Game/Utilities/UtilityBlueprints/BP_BZAsset_BoilerPlate"
 
+SOCKET_BONE_PREFIX = "_sock_"   # all sockets are confirmed to start with this
+SOCKET_FLIP_SCALE = (1, -1, -1)
+
+
+def _flip_socket_bones_on_mesh(skeletal_mesh_path):
+    """Mirror socket bones on a freshly (re)imported SKM.
+
+    Automated equivalent of the 'Skeletal Mesh Update' editor utility widget:
+    scales every bone whose name starts with `_sock_` by `(1, -1, -1)`.
+    Imported locally and wrapped so a failure only logs — it must never abort
+    the asset import pipeline.
+    """
+    try:
+        import skeletal_mesh_helpers  # lives in /Content/Python
+        skeletal_mesh_helpers.set_scale_for_bones_matching(
+            skeletal_mesh_path, SOCKET_BONE_PREFIX,
+            scale=SOCKET_FLIP_SCALE, prefix_only=True)
+    except Exception as exc:
+        unreal.log_warning(f"[Socket Flip] Skipped {skeletal_mesh_path}: {exc}")
+
 
 def get_blueprint_name(asset_name, version):
     """Add BP_ prefix and version suffix to asset name."""
@@ -267,6 +287,9 @@ class SkeletalMeshFBXLoader(plugin.Loader):
                 # directly saving the skeletal mesh either, inconsistent
                 unreal.EditorAssetLibrary.save_loaded_asset(newly_imported_SKM)
 
+                # Mirror-flip socket bones (`_sock_` prefix) on the fresh SKM
+                _flip_socket_bones_on_mesh(asset_dir + '/' + asset_name)
+
 
             if created_temp_material:
                 # Delete temporary base material, only if we created it, as we
@@ -475,6 +498,11 @@ class SkeletalMeshFBXLoader(plugin.Loader):
             # I am considering not doing this save since we're not
             # directly saving the skeletal mesh either, inconsistent
             unreal.EditorAssetLibrary.save_loaded_asset(newly_imported_SKM)
+
+            # Mirror-flip socket bones (`_sock_` prefix); reimport resets the
+            # ref pose from the FBX, so this has to run on update too
+            _flip_socket_bones_on_mesh(
+                container["namespace"] + '/' + container["asset_name"])
 
             # UE 5.7+: Update Blueprint wrapper's SkeletalMeshComponent
             if is5_7_or_later:


### PR DESCRIPTION
Previously, immediately after importing an asset through the UE fbx hook and importing shot animation similarly, we would have to run 2 separate tools via asset utilities and an editor blueprint utility, these called python code in a local library skeletal-mesh-helpers.py. I have integrated this into the load/update paths for both import types and wrapped it in a local import so that if the lib is missing for whatever reason we don't bomb the entire load.
